### PR TITLE
Ignoring hide/show buttons logic on the last instrument

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -142,6 +142,7 @@ class ExternalModule extends AbstractExternalModule {
             'formsAccess' => $forms_access,
             'location' => $location,
             'instrument' => $instrument,
+            'isLastForm' => $Proj->lastFormName == $instrument,
             'hideNextRecordButton' => $this->getProjectSetting('hide-next-record-button', $Proj->project_id),
         );
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module forces a linear data entry workflow across REDCap forms and events. 
 
 
 ## Installation
-- Clone this repo into to `<redcap-root>/modules/linear_data_entry_workflow_v2.0`.
+- Clone this repo into to `<redcap-root>/modules/linear_data_entry_workflow_v<version_number>`.
 - Go to **Control Center > Manage External Modules** and enable Linear Data Entry Workflow.
 - For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable Linear Data Entry Workflow for that project.
 

--- a/js/rfio.js
+++ b/js/rfio.js
@@ -67,6 +67,10 @@ document.addEventListener('DOMContentLoaded', function() {
      * Hide "Save and Continue to Next Form" buttons.
      */
     function hideNextFormButtons() {
+        if (settings.isLastForm) {
+            return;
+        }
+
         const FORM_STATUS_COMPLETE = '2';
 
         var $complete = $('[name="' + settings.instrument + '_complete"]');


### PR DESCRIPTION
This PR fixes a conflict between LDEW and [Send Rx](https://github.com/ctsit/send_rx). On prescription last step (Review & Send Rx) a few buttons remain disabled even if the form set as complete.

Review steps:
- [ ] Make sure you have a working Send Rx environment
- [ ] Create a new prescription data entry and move forward to the last step (Review & Send Rx)
- [ ] Make sure the submission buttons are disabled
- [ ] Switch form to completed and make sure **all buttons** got enabled