### PR TITLE
Fix auto-locking bugs and add exception list feature

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -56,7 +56,7 @@ class ExternalModule extends AbstractExternalModule {
 
         if ($this->loadRFIO('data_entry_form', $Proj->eventInfo[$event_id]['arm_num'], $record, $event_id, $instrument)) {
             $this->loadFDEC($instrument);
-            $this->loadAutoLock();
+            $this->loadAutoLock($instrument);
         }
     }
 
@@ -254,9 +254,19 @@ class ExternalModule extends AbstractExternalModule {
     /**
      * Loads auto-lock feature.
      */
-    protected function loadAutoLock() {
+    protected function loadAutoLock($instrument) {
       global $user_rights;
       global $Proj;
+
+      //get list of exceptions
+      if (!$exceptions = $this->getProjectSetting('forms-exceptions', $Proj->project_id)) {
+          $exceptions = array();
+      }
+
+      //if current form is in the exception list then disable auto-locking
+      if (in_array($instrument, $exceptions)) {
+        return;
+      }
 
       //get list of roles to enforce auto-locking on
       $roles_to_lock = $this->getProjectSetting("auto-locked-roles", $Proj->project_id);

--- a/js/auto-lock.js
+++ b/js/auto-lock.js
@@ -8,6 +8,13 @@ document.addEventListener('DOMContentLoaded', function() {
     $unlockBtn.hide();
   } else {
     $lockRecordRow.hide();
-    $lockRecordCheckBox.prop('checked', true);
+    $formCompleteDropdown = $('select[name$="_complete"]');
+    $formCompleteDropdown.change(function(event) {
+      if($formCompleteDropdown.val() == "2") {
+        $lockRecordCheckBox.prop('checked', true);
+      } else {
+        $lockRecordCheckBox.prop('checked', false);
+      }
+    });
   }
 });

--- a/js/auto-lock.js
+++ b/js/auto-lock.js
@@ -1,15 +1,22 @@
 document.addEventListener('DOMContentLoaded', function() {
 
+  //get UI elements of interest
   var $lockRecordRow = $('#__LOCKRECORD__-tr');
   var $lockRecordCheckBox = $('#__LOCKRECORD__');
 
+  //if form is already locked
   if($lockRecordCheckBox.is(":checked")) {
+    //hide unlock button
     $unlockBtn = $('input[value="Unlock form"]');
     $unlockBtn.hide();
   } else {
+    //hide row with the lock button
     $lockRecordRow.hide();
+
+    //when the form_complete dropdown is changed
     $formCompleteDropdown = $('select[name$="_complete"]');
     $formCompleteDropdown.change(function(event) {
+      //if the form_complete value is set to "complete" then lock the form
       if($formCompleteDropdown.val() == "2") {
         $lockRecordCheckBox.prop('checked', true);
       } else {


### PR DESCRIPTION
- [x] create a user that is not a REDCap administrator (this module does not affect admins).
- [x] create a role with locking/unlocking privileges and assign it to one of the users you created.
- [x] configure the module to activate auto-locking for the role you just created.
- [x] log in as the user with auto-locking enabled and verify that...
    - [x] The lock-form button cannot be accessed when the form is being initially filled out.
    - [x] forms are locked if they have been marked as complete and then saved.
    - [ ] The user cannot unlock a locked form.
    - [x] REDCap reverts to normal behavior if the instrument is in the exception list.
    - [x] This feature does not interfere with FDEC features.