### PR TITLE
Changing algorithm to hide forms

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -86,7 +86,10 @@ class ExternalModule extends AbstractExternalModule {
         // Proj is a REDCap var used to pass information about the current project.
         global $Proj;
 
-        $forms_status = Records::getFormStatus($Proj->project_id, $record ? array($record) : null);
+        $records = $record ? array($record) : Records::getRecordList($Proj->project_id);
+        $events = $event_id ? array($event_id => $Proj->eventsForms[$event_id]) : array();
+
+        $forms_status = Records::getFormStatus($Proj->project_id, $records, $arm, null, $events);
 
         if ($independent_events_allowed = $this->getProjectSetting('allow-independent-events')) {
             foreach ($forms_status as $id => $data) {

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -102,11 +102,8 @@ class ExternalModule extends AbstractExternalModule {
         }
 
         // Handling possible conflicts with CTSIT's Form Render Skip Logic.
-        $prefix = 'form_render_skip_logic';
-        $enabled_modules = ExternalModules::getEnabledModules($Proj->project_id);
-        if (isset($enabled_modules[$prefix])) {
-            $frsl = ExternalModules::getModuleInstance($prefix, $enabled_modules[$prefix]);
-            $frsl_forms_access = $frsl->getFormsAccessMatrix($arm, $record);
+        if (defined('FORM_RENDER_SKIP_LOGIC_PREFIX')) {
+            $frsl_forms_access = ExternalModules::getModuleInstance(FORM_RENDER_SKIP_LOGIC_PREFIX)->getFormsAccessMatrix($event_id, $record);
         }
 
         $independent_events_allowed = $this->getProjectSetting('allow-independent-events');

--- a/js/rfio.js
+++ b/js/rfio.js
@@ -37,7 +37,12 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         var params = getQueryParameters(this.href);
-        if (!settings.formsAccess[params.id][params.event_id][params.page]) {
+
+        if (typeof settings.deniedForms[params.id][params.event_id] === 'undefined') {
+            return;
+        }
+
+        if (typeof settings.deniedForms[params.id][params.event_id][params.page] !== 'undefined') {
             disableForm(this);
         }
     });

--- a/js/rfio.js
+++ b/js/rfio.js
@@ -38,11 +38,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
         var params = getQueryParameters(this.href);
 
-        if (typeof settings.deniedForms[params.id][params.event_id] === 'undefined') {
-            return;
-        }
-
-        if (typeof settings.deniedForms[params.id][params.event_id][params.page] !== 'undefined') {
+        if (
+            typeof settings.deniedForms[params.id] !== 'undefined' &&
+            typeof settings.deniedForms[params.id][params.event_id] !== 'undefined' &&
+            typeof settings.deniedForms[params.id][params.event_id][params.page] !== 'undefined'
+        ) {
             disableForm(this);
         }
     });


### PR DESCRIPTION
- Changing algorithm: "Run the longitudinal grid backwards, and keep hiding forms until a populated form is found."
- Updates FRSL integration to follow the new `getFormsAccessMatrix()` parameters in https://github.com/ctsit/form_render_skip_logic/pull/29.