### PR TITLE
warn user and disable complete option with bad data

### DIFF
--- a/js/fdec.js
+++ b/js/fdec.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', function() {
      */
     function formValidate(elements_validate, required_fields_selector = '', statuses_bypass = [], display_popup = true) {
         // Checking if current form status can bypass validation.
-        if ( (statuses_bypass.length && statuses_bypass.includes($formStatus.val()))) {
+        if (statuses_bypass.length && statuses_bypass.includes($formStatus.val())) {
             return true;
         }
 

--- a/js/fdec.js
+++ b/js/fdec.js
@@ -14,29 +14,46 @@ document.addEventListener('DOMContentLoaded', function() {
     // Overriding submit callbacks according to our needs.
     overrideSubmitCallbacks();
 
+    var warned = false;
     $formStatus.change(function() {
         if (!settings.statusesBypass.includes($formStatus.val())) {
             // Submit callbacks need to be overriden if form status changes.
             overrideSubmitCallbacks();
+
+            var failed = !formValidate(true, settings.requiredFieldsSelector, statuses_bypass = [], display_popup = true);
+            $(this).children('option[value="2"]').prop('disabled', failed); // disable the complete option
+
+            if (failed) {
+                warned = true;
+                $(this).val(0); // TODO: what if value 0 is not bypassed?
+            }
         }
+    });
+
+    // evaluate on dropdown selection
+    $formStatus.focus(function() {
+            if (warned) {
+                var failed = !formValidate(true, settings.requiredFieldsSelector, statuses_bypass = [], display_popup = false);
+                $(this).children('option[value="2"]').prop('disabled', failed);
+            }
     });
 
     /**
      * Form validation callback.
      */
-    function formValidate(elements_validate, required_fields_selector = '', statuses_bypass = []) {
+    function formValidate(elements_validate, required_fields_selector = '', statuses_bypass = [], display_popup = true) {
         // Checking if current form status can bypass validation.
-        if (statuses_bypass.length && statuses_bypass.includes($formStatus.val())) {
+        if ( (statuses_bypass.length && statuses_bypass.includes($formStatus.val()))) {
             return true;
         }
 
         // Checking for inconsistent data.
-        if (elements_validate && !fieldsConsistencyValidate()) {
+        if (elements_validate && !fieldsConsistencyValidate(display_popup)) {
             return false;
         }
 
         // Checking for empty required fields.
-        if (required_fields_selector && !requiredFieldsValidate(required_fields_selector)) {
+        if (required_fields_selector && !requiredFieldsValidate(required_fields_selector, display_popup)) {
             return false;
         }
 
@@ -46,13 +63,15 @@ document.addEventListener('DOMContentLoaded', function() {
     /**
      * Function that checks whether fields values are consistent.
      */
-    function fieldsConsistencyValidate() {
+    function fieldsConsistencyValidate(display_popup = true) {
         var validated = true;
 
         // Running the validation callback of each form element (e.g. checking for numbers out of range).
         $('#questiontable input:visible, #questiontable select:visible').each(function() {
             if (typeof this.onblur === 'function') {
-                this.onblur.call(this);
+                if (display_popup) {
+                    this.onblur.call(this);
+                }
 
                 if ($(this).css('background-color') === FORM_ERROR_COLOR) {
                     // We've got a validation error.


### PR DESCRIPTION
Addresses issue #43 

If a user attempts to **mark** a form complete (even before clicking any of the save buttons) with missing or disallowed data in a required field, a warning will display telling them the fields with bad data and the `Complete` option in the `Complete?` drop-down menu will be unselectable until the issues are addressed.

![Screen Shot 2019-07-31 at 1 04 10 PM](https://user-images.githubusercontent.com/20332546/62232230-b92fe900-b393-11e9-8b6a-c4ca7e422546.png)


Even if the user corrects the fields to select `Complete`, then goes back and changes them to bad values, when trying to save a warning will be displayed again and the record will not be saved.

There is a possible deviation from expected behavior:  
If a field is **not** set as required, but _is subject to other constraints_ (e.g. an age field has bounds but is not required), the field must either be left blank or entered within the bounds for the record to be marked as `Complete`. If set to `Complete` prior to the entry of out of range data, a warning will be displayed (e.g. `The value you provided is outside the suggested range. (5 - 10). You may wish to verify.`) and the form will not save while `Complete` remains selected.  
Without the module on, default REDCap behavior is to warn the user to verify and allow saving with any answer to `Complete?`.