### PR TITLE
address bug causing autolocking of every form with no roles set

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -294,6 +294,7 @@ class ExternalModule extends AbstractExternalModule {
 
       //get list of roles to enforce auto-locking on
       $roles_to_lock = $this->getProjectSetting("auto-locked-roles", $Proj->project_id);
+      if (!isset($roles_to_lock[0])) return; // do not autolock if no autolock roles are set
 
       //load auto-lock script if user is in an auto-locked role
       if (in_array($user_rights["role_id"], $roles_to_lock)) {


### PR DESCRIPTION
Addresses issue #35 

To test:  
1. login as an admin user
1. create a new project, do not define any roles
1. enable the module on the project but do not define any autolock roles
1. create a new record, marking any form as complete
1. observe that the form does not autolock