### PR TITLE
check if an event is the final event before stopping assigning denied forms

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -170,7 +170,7 @@ class ExternalModule extends AbstractExternalModule {
                     $prev_event = '';
                     $prev_form = '';
                 }
-                elseif (!isset($denied_forms[$id][$prev_event][$prev_form])) {
+                elseif ( !isset($denied_forms[$id][$prev_event][$prev_form]) && $event != max(array_keys($data)) ) {
                     break;
                 }
             }


### PR DESCRIPTION
Addresses issue #48 

To test:
1. Create a project using @h3n0r1k's xml file in issue #48 
1. set the final form - `studienendabbruch` - as a "Forms Exceptions" in the project level configuration
1. observe that events are blocked as expected
    (example in Record Status Dashboard context):  
![image](https://user-images.githubusercontent.com/20332546/81100023-d1600600-8ed9-11ea-9d66-5feee86a82c3.png)
