### PR TITLE
check that prev_event is set before stopping assignment of denied forms

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -170,7 +170,7 @@ class ExternalModule extends AbstractExternalModule {
                     $prev_event = '';
                     $prev_form = '';
                 }
-                elseif ( !isset($denied_forms[$id][$prev_event][$prev_form]) && $event != max(array_keys($data)) ) {
+                elseif ( !isset($denied_forms[$id][$prev_event][$prev_form]) && $prev_event !== '' ) {
                     break;
                 }
             }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -119,13 +119,13 @@ class ExternalModule extends AbstractExternalModule {
             $frsl = ExternalModules::getModuleInstance(FORM_RENDER_SKIP_LOGIC_PREFIX)->getFormsAccessMatrix($event_id, $record);
         }
 
-        $prev_event = '';
-        $prev_form = '';
-
         // Getting denied forms.
         $denied_forms = array();
         foreach ($forms_status as $id => $data) {
             $denied_forms[$id] = array();
+
+            $prev_event = '';
+            $prev_form = '';
 
             foreach (array_reverse($data, true) as $event => $event_forms) {
                 $denied_forms[$id][$event] = array();


### PR DESCRIPTION
Addresses additional case of issue #48 

I believe the root cause of the issue was having any combination of forms excepted which result in coverage of entire events starting from the final event.

To test:
1. use the project from PR #50 
1. Assign exceptions in any way that results in complete coverage of events, working backwards from the final event. Examples:
    - `{StudienendeAbbruch}`
    - `{StudienendeAbbruch, Schwangerschaft Teil 1, Schwangerschaft Teil 2}`
    - `{StudienendeAbbruch, Schwangerschaft Teil 1, Schwangerschaft Teil 2, UE, SE}`
1. Observe that remaining remaining forms are treated as expected