### PR TITLE
adjust to support proper functioning on first record within a DAG

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -87,7 +87,15 @@ class ExternalModule extends AbstractExternalModule {
         global $Proj;
 
         $records = $record ? array($record) : Records::getRecordList($Proj->project_id);
-        $forms_status = Records::getFormStatus($Proj->project_id, $records, $arm);
+
+        if ( !$forms_status = Records::getFormStatus($Proj->project_id, $records, $arm) ) {
+            // Synthesize $forms_status for first record in a DAG
+            $id = $records[0];
+            $forms_status = [$id => $Proj->eventsForms];
+            foreach($forms_status[$id] as $event => $forms) {
+                $forms_status[$id][$event] = array_fill_keys($forms, []);
+            }
+        }
 
         if ($independent_events_allowed = $this->getProjectSetting('allow-independent-events')) {
             foreach ($forms_status as $id => $data) {


### PR DESCRIPTION
Addresses issue #53 

Creates and structures an array of events and forms for the first record in a DAG, simulating the expected output from `Records::getFormStatus`.

To test:  
1. Create or open a project built using the example XML included in this repo
1. Create a dag and assign a user to it (I used Carol)
1. Access the project as Carol
1. Attempt to add a record
1. Observe that only "My First Instrument" is accessible