### PR TITLE
Skip "next form" logic when user is not in an instrument

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -199,7 +199,7 @@ class ExternalModule extends AbstractExternalModule {
             'hideNextRecordButton' => $this->getProjectSetting('hide-next-record-button', $Proj->project_id),
         );
 
-        if (!$settings['forceButtonsDisplay']) {
+        if (!$settings['forceButtonsDisplay'] && !is_null($event_id)) {
             $i = array_search($instrument, $Proj->eventsForms[$event_id]);
             $next_form = $Proj->eventsForms[$event_id][$i + 1];
 

--- a/config.json
+++ b/config.json
@@ -8,19 +8,9 @@
     ],
     "authors": [
         {
-            "name": "Philip Chase",
-            "email": "pbc@ufl.edu",
+            "name": "University of Florida CTS-IT",
+            "email": "CTSIT-REDCAP-MODULE-SUPPO@LISTS.UFL.EDU",
             "institution": "University of Florida - CTSI"
-        },
-        {
-            "name": "Taryn Stoffs",
-            "email": "tls@ufl.edu",
-            "institution": "University of Florida - CTSI"
-        },
-        {
-            "name": "Kyle Chesney",
-            "email": "kyle.chesney@ufl.edu",
-            "institution": "University of Florida"
         }
     ],
     "project-settings": [


### PR DESCRIPTION
Closes #58

Prevents an error in PHP8+ caused by array_search(null, null) which previously only threw a warning  
Additionally ensures inaccessible forms have their icons greyed out during new record creation